### PR TITLE
Update pgVersion.py

### DIFF
--- a/pgVersion.py
+++ b/pgVersion.py
@@ -54,7 +54,7 @@ class PgVersion(QObject):
     self.tools = PgVersionTools(self)
 
     #Initialise thetranslation environment    
-    self.plugin_path = os.path.dirname(os.path.realpath(__file__))
+    self.plugin_path = QDir.cleanPath( os.path.abspath(os.path.dirname(__file__)) )
     myLocaleName = QLocale.system().name()
     myLocale = myLocaleName[0:2]
     if QFileInfo(self.plugin_path).exists():


### PR DESCRIPTION
prevent problems with path on windows os:
before:
C:\QGIS_INSTALL_PATH\configpath_folder\python\plugins\pgversion
after
C:/QGIS_INSTALL_PATH/configpath_folder/python/plugins/pgversion

fixes problem in Ui_dbVersionCheck.py where file can not be opened on windows os if the path is not clean